### PR TITLE
Shrink default dispatchers to be used in tests

### DIFF
--- a/test/src/main/resources/reference.conf
+++ b/test/src/main/resources/reference.conf
@@ -10,9 +10,15 @@ akka {
   actor {
     default-dispatcher {
       fork-join-executor {
-        parallelism-min = 4
-        parallelism-factor = 1.0
-        parallelism-max = 8
+        parallelism-min = 2
+        parallelism-factor = 0.5
+        parallelism-max = 4
+      }
+    }
+
+    default-blocking-io-dispatcher {
+      thread-pool-executor {
+        fixed-pool-size = 2
       }
     }
   }


### PR DESCRIPTION
At the moment thread pool size for default blocking IO dispatcher is 16 which is hardly ever needed for most of the tests. 
Same for default dispatcher - 8 warm threads is very rare to be required. And in case 4 is not enough, fork-join will expand on demand.