### PR TITLE
Add blocking tracker for instrumented dispatcher

### DIFF
--- a/instrumentation/src/main/scala/com/evolutiongaming/util/dispatchers/InstrumentedConfig.scala
+++ b/instrumentation/src/main/scala/com/evolutiongaming/util/dispatchers/InstrumentedConfig.scala
@@ -9,7 +9,9 @@ case class InstrumentedConfig(
   id: String,
   mdc: Boolean,
   metrics: Boolean,
-  executionTracker: Option[InstrumentedConfig.ExecutionTracker])
+  executionTracker: Option[InstrumentedConfig.ExecutionTracker],
+  blockingTracker: Boolean,
+)
 
 object InstrumentedConfig {
 
@@ -18,7 +20,9 @@ object InstrumentedConfig {
       id = config.get[String]("id"),
       mdc = config.getOpt[Boolean]("mdc") getOrElse false,
       metrics = config.getOpt[Boolean]("metrics") getOrElse false,
-      executionTracker = config.getOpt[Config]("execution-tracker") flatMap ExecutionTracker.opt)
+      executionTracker = config.getOpt[Config]("execution-tracker") flatMap ExecutionTracker.opt,
+      blockingTracker = config.getOpt[Boolean]("blocking-tracker") getOrElse false,
+    )
   }
 
   

--- a/util/src/main/scala/com/evolutiongaming/util/BlockingTracker.scala
+++ b/util/src/main/scala/com/evolutiongaming/util/BlockingTracker.scala
@@ -1,0 +1,42 @@
+package com.evolutiongaming.util
+
+import com.evolutiongaming.util.ExecutionThreadTracker.stackTraceToString
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.BlockContext.withBlockContext
+import scala.concurrent.{BlockContext, CanAwait}
+
+object BlockingTracker extends LazyLogging {
+
+  trait Surround {def apply[T](f: () => T): T }
+
+  lazy val Empty = new Surround {
+    override def apply[T](f: () => T): T = f()
+  }
+
+  def apply(enabled: Boolean): Surround = {
+    if (enabled) {
+      new Surround {
+        override def apply[T](f: () => T): T = {
+
+          val nonTracking = BlockContext.current
+
+          val tracking = new BlockContext {
+            override def blockOn[A](thunk: => A)(implicit permission: CanAwait): A = {
+
+              val stacktrace = stackTraceToString(Thread.currentThread().getStackTrace)
+              val name = Thread.currentThread().getName
+              logger.warn(s"Thread $name is about to block on: $stacktrace")
+
+              nonTracking.blockOn(thunk)
+            }
+          }
+
+          withBlockContext(tracking) { f() }
+        }
+      }
+    } else {
+      Empty
+    }
+  }
+}

--- a/util/src/main/scala/com/evolutiongaming/util/BlockingTracker.scala
+++ b/util/src/main/scala/com/evolutiongaming/util/BlockingTracker.scala
@@ -10,7 +10,7 @@ object BlockingTracker extends LazyLogging {
 
   trait Surround {def apply[T](f: () => T): T }
 
-  lazy val Empty = new Surround {
+  val Empty: Surround = new Surround {
     override def apply[T](f: () => T): T = f()
   }
 
@@ -24,8 +24,9 @@ object BlockingTracker extends LazyLogging {
           val tracking = new BlockContext {
             override def blockOn[A](thunk: => A)(implicit permission: CanAwait): A = {
 
-              val stacktrace = stackTraceToString(Thread.currentThread().getStackTrace)
-              val name = Thread.currentThread().getName
+              val thread = Thread.currentThread()
+              val stacktrace = stackTraceToString(thread.getStackTrace)
+              val name = thread.getName
               logger.warn(s"Thread $name is about to block on: $stacktrace")
 
               nonTracking.blockOn(thunk)


### PR DESCRIPTION
Given enhancement allows overriding default BlockContext and log a warn with stacktrace.
Configuration options `blocking-tracker` by default is false, when set to `true` will produce a warn.